### PR TITLE
Fix old and broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,5 +122,5 @@ antidote:commit_transaction(TxId1).
 # output: {ok, ...}
 ```
 
-Look at the documentation to see more examples of AntidoteDB in action. We are working on new features for AntidoteDB, contact us at info@antidotedb.com if you want to know more.
+Look at the documentation to see more examples of AntidoteDB in action. We are working on new features for AntidoteDB, contact us at [info@antidotedb.com](mailto:info@antidotedb.com) if you want to know more.
 

--- a/api/protocol-buffer-api.md
+++ b/api/protocol-buffer-api.md
@@ -9,7 +9,7 @@ description: Here we describe the Erlang client for Antidote’s protocol buffer
 {% endhint %}
 
 {% hint style="info" %}
-**Note:** If you want to use this interface, you need to add [antidote\_pb](https://github.com/SyncFree/antidote_pb) to your application’s rebar dependencies.
+**Note:** If you want to use this interface, you need to add [antidote\_pb](https://github.com/AntidoteDB/antidote_pb) to your application’s rebar dependencies.
 {% endhint %}
 
 ### Transactions <a id="transactions"></a>

--- a/overview/architecture.md
+++ b/overview/architecture.md
@@ -16,7 +16,9 @@ Each partition in AntidoteDB mainly consists of the following four components:
 
 ## Log
 
-This module implements a log-based persistent layer. Updates are stored in a log, which is persisted to disk for durability. The module also internally maintains a cache layer in order to make accesses to the log faster. Further details can be found [here](https://syncfree.github.io/antidote/log.html).
+This module implements a log-based persistent layer. Updates are stored in a log, which is persisted to disk for durability. The module also internally maintains a cache layer in order to make accesses to the log faster. For further details :
+
+{% page-ref page="overview/caches-and-logs.md" %
 
 ## Materializer
 

--- a/overview/caches-and-logs.md
+++ b/overview/caches-and-logs.md
@@ -8,7 +8,7 @@ Logs and caches will be explained using two scripts `cache_dump.erl` and `log_du
 
 #### General
 
-[Antidote](https://github.com/SyncFree/antidote)
+[Antidote](https://github.com/AntidoteDB/antidote)
 
 [Erlang Remote Procedure Calls](http://erlang.org/doc/man/rpc.html) All of the interaction with Antidote is executed via RPC calls
 

--- a/overview/installation.md
+++ b/overview/installation.md
@@ -8,7 +8,7 @@ description: Getting started with Antidote.
 
 ### Prerequisites <a id="prerequisites"></a>
 
-* Working recent version of Docker \(1.12 and up recommended\)
+* Working recent version of [Docker](https://docs.docker.com/install/) \(1.12 and up recommended\)
 
 ### Starting a local node <a id="starting-a-local-node"></a>
 
@@ -33,12 +33,12 @@ Antidote should now be running on port 8087 on localhost.
 
 #### Getting Antidote
 
-The source code is available open-source at [Github](https://github.com/SyncFree/antidote).
+The source code is available open-source at [Github](https://github.com/AntidoteDB/antidote).
 
 You can clone it to your machine via
 
 ```text
-git clone git@github.com:SyncFree/antidote.git
+git clone git@github.com:AntidoteDB/antidote.git
 ```
 
 #### Building a single node cluster
@@ -62,7 +62,7 @@ Type `Ctrl-g` and `q` to quit the shell and stop the node.
 
 #### Reading from and writing to a CRDT object stored in antidote: <a id="reading-from-and-writing-to-a-crdt-object-stored-in-antidote"></a>
 
-Antidote can store and manage different [crdts](https://github.com/SyncFree/antidote_crdt). Here we see how to update and read a counter.
+Antidote can store and manage different [crdts](https://github.com/AntidoteDB/antidote_crdt). Here we see how to update and read a counter.
 
 Start a node \(if you haven’t done it yet\):
 
@@ -107,7 +107,9 @@ CounterObj = {my_counter, antidote_crdt_counter_pn, my_bucket}.
 [CounterVal] = Res.
 ```
 
- More about the API is described [here](https://syncfree.github.io/antidote/rawapi.html).
+ More about the API is described here :
+  
+ {% page-ref page="api/native-api.md" %}
 
 ###  Running Tests
 


### PR DESCRIPTION
Updated doc internal and external links.

Note: the link to Antidote github repo in the menu bar still needs to be updated via Gitbook.